### PR TITLE
Twig 2.0 compatibility, dropdownParent and bootstrap3 form theme

### DIFF
--- a/src/Zitec/FormAutocompleteBundle/Form/Type/AutocompleteType.php
+++ b/src/Zitec/FormAutocompleteBundle/Form/Type/AutocompleteType.php
@@ -128,6 +128,7 @@ class AutocompleteType extends AbstractType
                 'context' => null,
                 // Must be set to true if the used Select2 version is lower than 4.0.0.
                 'compatibility' => false,
+                'dropdownParent' => false
             ))
             ->setAllowedTypes('data_resolver', 'string')
             ->setAllowedTypes('autocomplete_path', array('null', 'string'))
@@ -167,6 +168,7 @@ class AutocompleteType extends AbstractType
         $view->vars['other_select2_options'] = $options['other_select2_options'];
         $view->vars['context'] = $options['context'];
         $view->vars['compatibility'] = $options['compatibility'];
+        $view->vars['dropdownParent'] = $options['dropdownParent'];
     }
 
     /**

--- a/src/Zitec/FormAutocompleteBundle/Resources/public/js/autocomplete.js
+++ b/src/Zitec/FormAutocompleteBundle/Resources/public/js/autocomplete.js
@@ -183,14 +183,27 @@
 
         options.allowClear = this.data.allowClear;
         if (options.allowClear && !this.compatibility) {
-            this.element.on('select2:unselecting', function() {
+            this.element.on('select2:unselecting', function () {
                 self.element.data('unselecting', true);
-            }).on('select2:open', function() {
+            }).on('select2:open', function () {
                 if (self.element.data('unselecting')) {
                     self.element.removeData('unselecting');
                     self.element.select2('close');
                 }
             });
+        }
+    };
+
+    /**
+     * Sets the parent class for the dropdown
+     *
+     * @param {Object} options
+     *
+     * @private
+     */
+    Autocomplete.prototype.configureDropdownParent = function (options) {
+        if (this.data.dropdownParent) {
+            options.dropdownParent = $(this.data.dropdownParent);
         }
     };
 
@@ -223,6 +236,7 @@
         this.configureInitialSelection(options);
         this.configureMultipleElement(options);
         this.configureAllowClear(options);
+        this.configureDropdownParent(options);
 
         this.addOtherOptions(options);
 

--- a/src/Zitec/FormAutocompleteBundle/Resources/views/Form/bootstrap_3_fields.html.twig
+++ b/src/Zitec/FormAutocompleteBundle/Resources/views/Form/bootstrap_3_fields.html.twig
@@ -1,0 +1,9 @@
+{# The template for the zitec_autocomplete field. #}
+{# The rendering differs from the compatibility mode to the default one, so we will have two different templates. #}
+
+{% extends '@ZitecFormAutocomplete/Form/fields.html.twig' %}
+
+{% block zitec_autocomplete_widget -%}
+    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
+    {{- parent() -}}
+{%- endblock zitec_autocomplete_widget %}

--- a/src/Zitec/FormAutocompleteBundle/Resources/views/Form/bootstrap_3_fields.html.twig
+++ b/src/Zitec/FormAutocompleteBundle/Resources/views/Form/bootstrap_3_fields.html.twig
@@ -1,6 +1,6 @@
 {# The bootstrap3 template for the zitec_autocomplete field. #}
 
-{% extends '@ZitecFormAutocomplete/Form/fields.html.twig' %}
+{% use '@ZitecFormAutocomplete/Form/fields.html.twig' %}
 
 {% block zitec_autocomplete_widget -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}

--- a/src/Zitec/FormAutocompleteBundle/Resources/views/Form/bootstrap_3_fields.html.twig
+++ b/src/Zitec/FormAutocompleteBundle/Resources/views/Form/bootstrap_3_fields.html.twig
@@ -1,5 +1,4 @@
-{# The template for the zitec_autocomplete field. #}
-{# The rendering differs from the compatibility mode to the default one, so we will have two different templates. #}
+{# The bootstrap3 template for the zitec_autocomplete field. #}
 
 {% extends '@ZitecFormAutocomplete/Form/fields.html.twig' %}
 

--- a/src/Zitec/FormAutocompleteBundle/Resources/views/Form/fields.html.twig
+++ b/src/Zitec/FormAutocompleteBundle/Resources/views/Form/fields.html.twig
@@ -17,7 +17,7 @@
                 data-zitec-autocomplete="{{ {
                     url: autocomplete_path,
                     language: app.request.locale,
-                    placeholder: placeholder is not sameas(null) ? placeholder|trans({}, translation_domain) : null,
+                    placeholder: placeholder is not same as(null) ? placeholder|trans({}, translation_domain) : null,
                     delay: delay,
                     minimumInputLength: minimum_input_length,
                     allowClear: allow_clear,
@@ -45,7 +45,7 @@
                 data-zitec-autocomplete="{{ {
                     url: autocomplete_path,
                     language: app.request.locale,
-                    placeholder: placeholder is not sameas(null) ? placeholder|trans({}, translation_domain) : null,
+                    placeholder: placeholder is not same as(null) ? placeholder|trans({}, translation_domain) : null,
                     delay: delay,
                     minimumInputLength: minimum_input_length,
                     allowClear: allow_clear,

--- a/src/Zitec/FormAutocompleteBundle/Resources/views/Form/fields.html.twig
+++ b/src/Zitec/FormAutocompleteBundle/Resources/views/Form/fields.html.twig
@@ -23,7 +23,8 @@
                     allowClear: allow_clear,
                     otherOptions: other_select2_options,
                     context: context,
-                    compatibility: false
+                    compatibility: false,
+                    dropdownParent: dropdownParent
                 }|json_encode }}"
             >
                 {% if multiple and value|length > 0 %}
@@ -53,7 +54,8 @@
                     context: context,
                     compatibility: true,
                     defaults: value,
-                    multiple: multiple
+                    multiple: multiple,
+                    dropdownParent: dropdownParent
                 }|json_encode }}"
             />
         </div>


### PR DESCRIPTION
 - add Twig 2.0 compatibility
 - add the dropdownParent option for select2 
 - add a bootstrap3 form theme for the autocomplete field